### PR TITLE
bump setuptools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ publish = [
 
 [build-system]
 requires = [
-    "setuptools~=67.6"
+    "setuptools~=68.0"
 ]
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
Hi!

Thanks for a great little library -

to use this in nix based projects the version of setuptools needs to be updated, since nixpkgs is on major version 68.

I've tested that it still builds with the more recent version.